### PR TITLE
Create wns toast support for Master branch

### DIFF
--- a/www/MobileServices.Web.js
+++ b/www/MobileServices.Web.js
@@ -4,6 +4,7 @@
 // ----------------------------------------------------------------------------
 
 (function (global) {
+	var $__fileVersion__ = '1.2.9';
     /// <field name="$__modules__">
     /// Map module names to either their cached exports or a function which
     /// will define the module's exports when invoked.
@@ -10646,6 +10647,7 @@
 			gcm = function (push) {
 			    this._push = push;
 			},
+            wns = function (push) {
 			    this._push = push;
 			};
 		


### PR DESCRIPTION
To use this new MobileServices.Web.js file:

From the app side in Cordova:

if (client) {
// Register for notifications.
client.push.wns.registerNative(wnsRegId, $scope.getTags()).done(function
() {
}, function (err) {

});
}
This is the code I use on the server side.

//insert should use Script/Admin authentication admin, and we use master
key for the server.
//read is to use application key... This will ensure that if application
key is disclosed, it will not be able to insert to our table.

function insert(item, user, request) {

// Define a simple payload for a GCM notification.
var payload = {
"message": item.title
};

// Define a payload for the Windows Store toast notification.
var payloadwns = '<?xml version="1.0" encoding="utf-8"?><toast><visual>'
+
'<binding template="ToastText01">  <text id="1">' +
item.title + '</text></binding></visual></toast>';

request.execute({
success: function () {
// If the insert succeeds, send a notification.
// Send to all template registrations
push.send(item.tag, payload, {
success: function (pushResponse) {
console.log("Sent push:", pushResponse, payload);

// send a notification for windows (a native registration).
push.wns.send(item.tag, payloadwns, 'wns/toast', {
success: function (pushResponse) {
console.log("Sent push wns:", pushResponse);
request.respond();
},
error: function (pushResponse) {
console.log("Error Sending push wns:", pushResponse);
request.respond(500, { error: pushResponse });
}
});
},
error: function (pushResponse) {
console.log("Error Sending push:", pushResponse);
}
});
},
error: function (err) {
console.log("request.execute error", err)
request.respond();
}
});
}
